### PR TITLE
Get line rendering to work on GC3000

### DIFF
--- a/src/gallium/drivers/etnaviv/etnaviv_emit.c
+++ b/src/gallium/drivers/etnaviv/etnaviv_emit.c
@@ -441,6 +441,11 @@ etna_emit_state(struct etna_context *ctx)
       uint32_t val = etna_rasterizer_state(ctx->rasterizer)->PA_CONFIG;
       /*00A34*/ EMIT_STATE(PA_CONFIG, val & ctx->shader_state.PA_CONFIG);
    }
+   if (unlikely(dirty & (ETNA_DIRTY_RASTERIZER))) {
+      struct etna_rasterizer_state *rasterizer = etna_rasterizer_state(ctx->rasterizer);
+      /*00A38*/ EMIT_STATE(PA_LINE_UNK00A38, rasterizer->PA_LINE_WIDTH);
+      /*00A3C*/ EMIT_STATE(PA_LINE_UNK00A3C, rasterizer->PA_LINE_WIDTH);
+   }
    if (unlikely(dirty & (ETNA_DIRTY_SHADER))) {
       for (int x = 0; x < 10; ++x) {
          /*00A40*/ EMIT_STATE(PA_SHADER_ATTRIBUTES(x), ctx->shader_state.PA_SHADER_ATTRIBUTES[x]);

--- a/src/gallium/drivers/etnaviv/etnaviv_rasterizer.c
+++ b/src/gallium/drivers/etnaviv/etnaviv_rasterizer.c
@@ -25,6 +25,8 @@
 #include "etnaviv_context.h"
 #include "etnaviv_screen.h"
 
+#include "hw/common.xml.h"
+
 #include "etnaviv_translate.h"
 #include "util/u_math.h"
 #include "util/u_memory.h"
@@ -53,7 +55,8 @@ etna_rasterizer_state_create(struct pipe_context *pctx,
                    translate_cull_face(so->cull_face, so->front_ccw) |
                    translate_polygon_mode(so->fill_front) |
                    COND(so->point_quad_rasterization, VIVS_PA_CONFIG_POINT_SPRITE_ENABLE) |
-                   COND(so->point_size_per_vertex, VIVS_PA_CONFIG_POINT_SIZE_ENABLE);
+                   COND(so->point_size_per_vertex, VIVS_PA_CONFIG_POINT_SIZE_ENABLE) |
+                   COND(VIV_FEATURE(ctx->screen, chipMinorFeatures1, WIDE_LINE), VIVS_PA_CONFIG_UNK22);
    cs->PA_LINE_WIDTH = fui(so->line_width / 2.0f);
    cs->PA_POINT_SIZE = fui(so->point_size / 2.0f);
    cs->SE_DEPTH_SCALE = fui(so->offset_scale);


### PR DESCRIPTION
The GC3000 in i.MX6qp refuses to render lines when WIDE_LINE mode disabled.

This feature has existed for a long time (gc880, gc1000, ...) and the Vivante driver always uses it when available, even to draw "non-wide" lines. So should we, as the backward compatibility has been dropped.

Set the bit (when the feature is available) and the associated state.

Signed-off-by: Wladimir J. van der Laan <laanwj@gmail.com>

(let me know if I should do an update of the rnndb files first to rename the states from UNKxxx. Related etna_viv commit: https://github.com/etnaviv/etna_viv/commit/964a55bde1e7494057c1bcb2e4435376d5e88fd9)

Video: https://www.youtube.com/watch?v=KH1ApjtCCLg