### PR TITLE
Get line rendering to work on GC3000 (rebased)

### DIFF
--- a/src/gallium/drivers/etnaviv/etnaviv_emit.c
+++ b/src/gallium/drivers/etnaviv/etnaviv_emit.c
@@ -441,6 +441,11 @@ etna_emit_state(struct etna_context *ctx)
       uint32_t val = etna_rasterizer_state(ctx->rasterizer)->PA_CONFIG;
       /*00A34*/ EMIT_STATE(PA_CONFIG, val & ctx->shader_state.PA_CONFIG);
    }
+   if (unlikely(dirty & (ETNA_DIRTY_RASTERIZER))) {
+      struct etna_rasterizer_state *rasterizer = etna_rasterizer_state(ctx->rasterizer);
+      /*00A38*/ EMIT_STATE(PA_WIDE_LINE_WIDTH0, rasterizer->PA_LINE_WIDTH);
+      /*00A3C*/ EMIT_STATE(PA_WIDE_LINE_WIDTH1, rasterizer->PA_LINE_WIDTH);
+   }
    if (unlikely(dirty & (ETNA_DIRTY_SHADER))) {
       for (int x = 0; x < 10; ++x) {
          /*00A40*/ EMIT_STATE(PA_SHADER_ATTRIBUTES(x), ctx->shader_state.PA_SHADER_ATTRIBUTES[x]);

--- a/src/gallium/drivers/etnaviv/etnaviv_rasterizer.c
+++ b/src/gallium/drivers/etnaviv/etnaviv_rasterizer.c
@@ -25,6 +25,8 @@
 #include "etnaviv_context.h"
 #include "etnaviv_screen.h"
 
+#include "hw/common.xml.h"
+
 #include "etnaviv_translate.h"
 #include "util/u_math.h"
 #include "util/u_memory.h"
@@ -53,7 +55,8 @@ etna_rasterizer_state_create(struct pipe_context *pctx,
                    translate_cull_face(so->cull_face, so->front_ccw) |
                    translate_polygon_mode(so->fill_front) |
                    COND(so->point_quad_rasterization, VIVS_PA_CONFIG_POINT_SPRITE_ENABLE) |
-                   COND(so->point_size_per_vertex, VIVS_PA_CONFIG_POINT_SIZE_ENABLE);
+                   COND(so->point_size_per_vertex, VIVS_PA_CONFIG_POINT_SIZE_ENABLE) |
+                   COND(VIV_FEATURE(ctx->screen, chipMinorFeatures1, WIDE_LINE), VIVS_PA_CONFIG_WIDE_LINE);
    cs->PA_LINE_WIDTH = fui(so->line_width / 2.0f);
    cs->PA_POINT_SIZE = fui(so->point_size / 2.0f);
    cs->SE_DEPTH_SCALE = fui(so->offset_scale);

--- a/src/gallium/drivers/etnaviv/hw/cmdstream.xml.h
+++ b/src/gallium/drivers/etnaviv/hw/cmdstream.xml.h
@@ -8,9 +8,9 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- cmdstream.xml (  12621 bytes, from 2016-09-14 19:39:09)
-- copyright.xml (   1597 bytes, from 2016-09-14 19:39:09)
-- common.xml    (  20957 bytes, from 2016-09-14 19:40:08)
+- cmdstream.xml (  13632 bytes, from 2016-11-02 13:52:32)
+- copyright.xml (   1597 bytes, from 2016-10-29 07:29:22)
+- common.xml    (  23272 bytes, from 2016-10-29 14:18:57)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>
@@ -50,6 +50,7 @@ DEALINGS IN THE SOFTWARE.
 #define FE_OPCODE_STALL						0x00000009
 #define FE_OPCODE_CALL						0x0000000a
 #define FE_OPCODE_RETURN					0x0000000b
+#define FE_OPCODE_DRAW_NEW					0x0000000c
 #define FE_OPCODE_CHIP_SELECT					0x0000000d
 #define PRIMITIVE_TYPE_POINTS					0x00000001
 #define PRIMITIVE_TYPE_LINES					0x00000002
@@ -237,6 +238,23 @@ DEALINGS IN THE SOFTWARE.
 #define VIV_FE_CHIP_SELECT_HEADER_ENABLE_CHIP2			0x00000004
 #define VIV_FE_CHIP_SELECT_HEADER_ENABLE_CHIP1			0x00000002
 #define VIV_FE_CHIP_SELECT_HEADER_ENABLE_CHIP0			0x00000001
+
+#define VIV_FE_DRAW_NEW						0x00000000
+
+#define VIV_FE_DRAW_NEW_HEADER					0x00000000
+#define VIV_FE_DRAW_NEW_HEADER_OP__MASK				0xf8000000
+#define VIV_FE_DRAW_NEW_HEADER_OP__SHIFT			27
+#define VIV_FE_DRAW_NEW_HEADER_OP_DRAW_NEW			0x60000000
+#define VIV_FE_DRAW_NEW_HEADER_TYPE__MASK			0x00ff0000
+#define VIV_FE_DRAW_NEW_HEADER_TYPE__SHIFT			16
+#define VIV_FE_DRAW_NEW_HEADER_TYPE(x)				(((x) << VIV_FE_DRAW_NEW_HEADER_TYPE__SHIFT) & VIV_FE_DRAW_NEW_HEADER_TYPE__MASK)
+#define VIV_FE_DRAW_NEW_HEADER_UNK0				0x00000001
+
+#define VIV_FE_DRAW_NEW_COUNT					0x00000004
+
+#define VIV_FE_DRAW_NEW_START					0x00000008
+
+#define VIV_FE_DRAW_NEW_UNKNOWN					0x0000000c
 
 
 #endif /* CMDSTREAM_XML */

--- a/src/gallium/drivers/etnaviv/hw/common.xml.h
+++ b/src/gallium/drivers/etnaviv/hw/common.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  18940 bytes, from 2016-09-14 19:36:57)
-- common.xml    (  20957 bytes, from 2016-09-14 19:40:08)
-- state_hi.xml  (  25653 bytes, from 2016-09-14 19:39:09)
-- copyright.xml (   1597 bytes, from 2016-09-14 19:39:09)
-- state_2d.xml  (  51552 bytes, from 2016-09-14 19:39:09)
-- state_3d.xml  (  54603 bytes, from 2016-09-14 19:39:09)
-- state_vg.xml  (   5975 bytes, from 2016-09-14 19:39:09)
+- state.xml     (  19487 bytes, from 2016-11-05 06:17:49)
+- common.xml    (  23272 bytes, from 2016-10-29 14:18:57)
+- state_hi.xml  (  25653 bytes, from 2016-10-29 07:29:22)
+- copyright.xml (   1597 bytes, from 2016-10-29 07:29:22)
+- state_2d.xml  (  51552 bytes, from 2016-10-29 07:29:22)
+- state_3d.xml  (  55854 bytes, from 2016-11-05 06:17:49)
+- state_vg.xml  (   5975 bytes, from 2016-10-29 07:29:22)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>
@@ -243,76 +243,76 @@ DEALINGS IN THE SOFTWARE.
 #define chipMinorFeatures3_SH_ENHANCEMENTS1			0x00100000
 #define chipMinorFeatures3_SH_ENHANCEMENTS2			0x00200000
 #define chipMinorFeatures3_UNK22				0x00400000
-#define chipMinorFeatures3_UNK23				0x00800000
+#define chipMinorFeatures3_2D_FC_SOURCE				0x00800000
 #define chipMinorFeatures3_UNK24				0x01000000
 #define chipMinorFeatures3_UNK25				0x02000000
 #define chipMinorFeatures3_NEW_HZ				0x04000000
 #define chipMinorFeatures3_UNK27				0x08000000
 #define chipMinorFeatures3_UNK28				0x10000000
-#define chipMinorFeatures3_UNK29				0x20000000
+#define chipMinorFeatures3_SH_ENHANCEMENTS3			0x20000000
 #define chipMinorFeatures3_UNK30				0x40000000
 #define chipMinorFeatures3_UNK31				0x80000000
 #define chipMinorFeatures4_UNK0					0x00000001
-#define chipMinorFeatures4_UNK1					0x00000002
-#define chipMinorFeatures4_UNK2					0x00000004
+#define chipMinorFeatures4_PE_ENHANCEMENTS2			0x00000002
+#define chipMinorFeatures4_FRUSTUM_CLIP_FIX			0x00000004
 #define chipMinorFeatures4_UNK3					0x00000008
 #define chipMinorFeatures4_UNK4					0x00000010
-#define chipMinorFeatures4_UNK5					0x00000020
-#define chipMinorFeatures4_UNK6					0x00000040
+#define chipMinorFeatures4_2D_GAMMA				0x00000020
+#define chipMinorFeatures4_SINGLE_BUFFER			0x00000040
 #define chipMinorFeatures4_UNK7					0x00000080
 #define chipMinorFeatures4_UNK8					0x00000100
 #define chipMinorFeatures4_UNK9					0x00000200
 #define chipMinorFeatures4_UNK10				0x00000400
-#define chipMinorFeatures4_UNK11				0x00000800
-#define chipMinorFeatures4_UNK12				0x00001000
-#define chipMinorFeatures4_UNK13				0x00002000
+#define chipMinorFeatures4_TX_LERP_PRECISION_FIX		0x00000800
+#define chipMinorFeatures4_2D_COLOR_SPACE_CONVERSION		0x00001000
+#define chipMinorFeatures4_TEXTURE_ASTC				0x00002000
 #define chipMinorFeatures4_UNK14				0x00004000
 #define chipMinorFeatures4_UNK15				0x00008000
 #define chipMinorFeatures4_HALTI2				0x00010000
 #define chipMinorFeatures4_UNK17				0x00020000
 #define chipMinorFeatures4_SMALL_MSAA				0x00040000
 #define chipMinorFeatures4_UNK19				0x00080000
-#define chipMinorFeatures4_UNK20				0x00100000
-#define chipMinorFeatures4_UNK21				0x00200000
-#define chipMinorFeatures4_UNK22				0x00400000
-#define chipMinorFeatures4_UNK23				0x00800000
-#define chipMinorFeatures4_UNK24				0x01000000
-#define chipMinorFeatures4_UNK25				0x02000000
-#define chipMinorFeatures4_UNK26				0x04000000
-#define chipMinorFeatures4_UNK27				0x08000000
+#define chipMinorFeatures4_NEW_RA				0x00100000
+#define chipMinorFeatures4_2D_OPF_YUV_OUTPUT			0x00200000
+#define chipMinorFeatures4_2D_MULTI_SOURCE_BLT_EX2		0x00400000
+#define chipMinorFeatures4_NO_USER_CSC				0x00800000
+#define chipMinorFeatures4_ZFIXES				0x01000000
+#define chipMinorFeatures4_BUG_FIXES18				0x02000000
+#define chipMinorFeatures4_2D_COMPRESSION			0x04000000
+#define chipMinorFeatures4_PROBE				0x08000000
 #define chipMinorFeatures4_UNK28				0x10000000
-#define chipMinorFeatures4_UNK29				0x20000000
+#define chipMinorFeatures4_2D_SUPER_TILE_VERSION		0x20000000
 #define chipMinorFeatures4_UNK30				0x40000000
 #define chipMinorFeatures4_UNK31				0x80000000
 #define chipMinorFeatures5_UNK0					0x00000001
 #define chipMinorFeatures5_UNK1					0x00000002
 #define chipMinorFeatures5_UNK2					0x00000004
 #define chipMinorFeatures5_UNK3					0x00000008
-#define chipMinorFeatures5_UNK4					0x00000010
+#define chipMinorFeatures5_EEZ					0x00000010
 #define chipMinorFeatures5_UNK5					0x00000020
 #define chipMinorFeatures5_UNK6					0x00000040
 #define chipMinorFeatures5_UNK7					0x00000080
 #define chipMinorFeatures5_UNK8					0x00000100
 #define chipMinorFeatures5_HALTI3				0x00000200
 #define chipMinorFeatures5_UNK10				0x00000400
-#define chipMinorFeatures5_UNK11				0x00000800
+#define chipMinorFeatures5_2D_ONE_PASS_FILTER_TAP		0x00000800
 #define chipMinorFeatures5_UNK12				0x00001000
-#define chipMinorFeatures5_UNK13				0x00002000
-#define chipMinorFeatures5_UNK14				0x00004000
+#define chipMinorFeatures5_SEPARATE_SRC_DST			0x00002000
+#define chipMinorFeatures5_HALTI4				0x00004000
 #define chipMinorFeatures5_UNK15				0x00008000
-#define chipMinorFeatures5_UNK16				0x00010000
-#define chipMinorFeatures5_UNK17				0x00020000
+#define chipMinorFeatures5_ANDROID_ONLY				0x00010000
+#define chipMinorFeatures5_HAS_PRODUCTID			0x00020000
 #define chipMinorFeatures5_UNK18				0x00040000
 #define chipMinorFeatures5_UNK19				0x00080000
-#define chipMinorFeatures5_UNK20				0x00100000
+#define chipMinorFeatures5_PE_DITHER_FIX2			0x00100000
 #define chipMinorFeatures5_UNK21				0x00200000
 #define chipMinorFeatures5_UNK22				0x00400000
 #define chipMinorFeatures5_UNK23				0x00800000
 #define chipMinorFeatures5_UNK24				0x01000000
 #define chipMinorFeatures5_UNK25				0x02000000
 #define chipMinorFeatures5_UNK26				0x04000000
-#define chipMinorFeatures5_UNK27				0x08000000
-#define chipMinorFeatures5_UNK28				0x10000000
+#define chipMinorFeatures5_DEPTHSTENCIL_NATIVE_SUPPORT		0x08000000
+#define chipMinorFeatures5_V2_MSAA_COMP_FIX			0x10000000
 #define chipMinorFeatures5_UNK29				0x20000000
 #define chipMinorFeatures5_UNK30				0x40000000
 #define chipMinorFeatures5_UNK31				0x80000000

--- a/src/gallium/drivers/etnaviv/hw/isa.xml.h
+++ b/src/gallium/drivers/etnaviv/hw/isa.xml.h
@@ -8,8 +8,8 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- isa.xml       (  19227 bytes, from 2016-09-14 19:39:09)
-- copyright.xml (   1597 bytes, from 2016-09-14 19:39:09)
+- isa.xml       (  19227 bytes, from 2016-10-29 07:29:22)
+- copyright.xml (   1597 bytes, from 2016-10-29 07:29:22)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/gallium/drivers/etnaviv/hw/state.xml.h
+++ b/src/gallium/drivers/etnaviv/hw/state.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  18940 bytes, from 2016-09-14 19:36:57)
-- common.xml    (  20957 bytes, from 2016-09-14 19:40:08)
-- state_hi.xml  (  25653 bytes, from 2016-09-14 19:39:09)
-- copyright.xml (   1597 bytes, from 2016-09-14 19:39:09)
-- state_2d.xml  (  51552 bytes, from 2016-09-14 19:39:09)
-- state_3d.xml  (  54603 bytes, from 2016-09-14 19:39:09)
-- state_vg.xml  (   5975 bytes, from 2016-09-14 19:39:09)
+- state.xml     (  19487 bytes, from 2016-11-05 06:17:49)
+- common.xml    (  23272 bytes, from 2016-10-29 14:18:57)
+- state_hi.xml  (  25653 bytes, from 2016-10-29 07:29:22)
+- copyright.xml (   1597 bytes, from 2016-10-29 07:29:22)
+- state_2d.xml  (  51552 bytes, from 2016-10-29 07:29:22)
+- state_3d.xml  (  55854 bytes, from 2016-11-05 06:17:49)
+- state_vg.xml  (   5975 bytes, from 2016-10-29 07:29:22)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>
@@ -173,6 +173,8 @@ DEALINGS IN THE SOFTWARE.
 #define VIVS_FE_DMA_HIGH					0x0000066c
 
 #define VIVS_FE_AUTO_FLUSH					0x00000670
+
+#define VIVS_FE_UNK00674					0x00000674
 
 #define VIVS_FE_UNK00678					0x00000678
 
@@ -355,6 +357,8 @@ DEALINGS IN THE SOFTWARE.
 
 #define VIVS_GL_CONTEXT_POINTER					0x00003850
 
+#define VIVS_GL_UNK03854					0x00003854
+
 #define VIVS_GL_UNK03A00					0x00003a00
 
 #define VIVS_GL_STALL_TOKEN					0x00003c00
@@ -366,6 +370,20 @@ DEALINGS IN THE SOFTWARE.
 #define VIVS_GL_STALL_TOKEN_TO(x)				(((x) << VIVS_GL_STALL_TOKEN_TO__SHIFT) & VIVS_GL_STALL_TOKEN_TO__MASK)
 #define VIVS_GL_STALL_TOKEN_FLIP0				0x40000000
 #define VIVS_GL_STALL_TOKEN_FLIP1				0x80000000
+
+#define VIVS_NFE						0x00000000
+
+#define VIVS_NFE_UNK14600(i0)				       (0x00014600 + 0x4*(i0))
+#define VIVS_NFE_UNK14600__ESIZE				0x00000004
+#define VIVS_NFE_UNK14600__LEN					0x00000010
+
+#define VIVS_NFE_UNK14640(i0)				       (0x00014640 + 0x4*(i0))
+#define VIVS_NFE_UNK14640__ESIZE				0x00000004
+#define VIVS_NFE_UNK14640__LEN					0x00000010
+
+#define VIVS_NFE_UNK14680(i0)				       (0x00014680 + 0x4*(i0))
+#define VIVS_NFE_UNK14680__ESIZE				0x00000004
+#define VIVS_NFE_UNK14680__LEN					0x00000010
 
 #define VIVS_DUMMY						0x00000000
 

--- a/src/gallium/drivers/etnaviv/hw/state_3d.xml.h
+++ b/src/gallium/drivers/etnaviv/hw/state_3d.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  18940 bytes, from 2016-09-14 19:36:57)
-- common.xml    (  20957 bytes, from 2016-09-14 19:40:08)
-- state_hi.xml  (  25653 bytes, from 2016-09-14 19:39:09)
-- copyright.xml (   1597 bytes, from 2016-09-14 19:39:09)
-- state_2d.xml  (  51552 bytes, from 2016-09-14 19:39:09)
-- state_3d.xml  (  54603 bytes, from 2016-09-14 19:39:09)
-- state_vg.xml  (   5975 bytes, from 2016-09-14 19:39:09)
+- state.xml     (  19487 bytes, from 2016-11-05 06:17:49)
+- common.xml    (  23272 bytes, from 2016-10-29 14:18:57)
+- state_hi.xml  (  25653 bytes, from 2016-10-29 07:29:22)
+- copyright.xml (   1597 bytes, from 2016-10-29 07:29:22)
+- state_2d.xml  (  51552 bytes, from 2016-10-29 07:29:22)
+- state_3d.xml  (  55854 bytes, from 2016-11-05 06:17:49)
+- state_vg.xml  (   5975 bytes, from 2016-10-29 07:29:22)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>
@@ -244,6 +244,12 @@ DEALINGS IN THE SOFTWARE.
 
 #define VIVS_VS_NEW_UNK00860					0x00000860
 
+#define VIVS_VS_UNK00864					0x00000864
+
+#define VIVS_VS_UNK00868					0x00000868
+
+#define VIVS_VS_UNK0086C					0x0000086c
+
 #define VIVS_VS_INST_MEM(i0)				       (0x00004000 + 0x4*(i0))
 #define VIVS_VS_INST_MEM__ESIZE					0x00000004
 #define VIVS_VS_INST_MEM__LEN					0x00000400
@@ -385,12 +391,12 @@ DEALINGS IN THE SOFTWARE.
 #define VIVS_PA_CONFIG_SHADE_MODEL_FLAT				0x00000000
 #define VIVS_PA_CONFIG_SHADE_MODEL_SMOOTH			0x00010000
 #define VIVS_PA_CONFIG_SHADE_MODEL_MASK				0x00040000
-#define VIVS_PA_CONFIG_UNK22					0x00400000
-#define VIVS_PA_CONFIG_UNK22_MASK				0x00800000
+#define VIVS_PA_CONFIG_WIDE_LINE				0x00400000
+#define VIVS_PA_CONFIG_WIDE_LINE_MASK				0x00800000
 
-#define VIVS_PA_LINE_UNK00A38					0x00000a38
+#define VIVS_PA_WIDE_LINE_WIDTH0				0x00000a38
 
-#define VIVS_PA_LINE_UNK00A3C					0x00000a3c
+#define VIVS_PA_WIDE_LINE_WIDTH1				0x00000a3c
 
 #define VIVS_PA_SHADER_ATTRIBUTES(i0)			       (0x00000a40 + 0x4*(i0))
 #define VIVS_PA_SHADER_ATTRIBUTES__ESIZE			0x00000004
@@ -406,6 +412,8 @@ DEALINGS IN THE SOFTWARE.
 #define VIVS_PA_VIEWPORT_UNK00A80				0x00000a80
 
 #define VIVS_PA_VIEWPORT_UNK00A84				0x00000a84
+
+#define VIVS_PA_UNK00A88					0x00000a88
 
 #define VIVS_PA_VIEWPORT_UNK00A8C				0x00000a8c
 
@@ -442,9 +450,15 @@ DEALINGS IN THE SOFTWARE.
 
 #define VIVS_RA_EARLY_DEPTH					0x00000e08
 
+#define VIVS_RA_UNK00E0C					0x00000e0c
+
 #define VIVS_RA_MULTISAMPLE_UNK00E10(i0)		       (0x00000e10 + 0x4*(i0))
 #define VIVS_RA_MULTISAMPLE_UNK00E10__ESIZE			0x00000004
 #define VIVS_RA_MULTISAMPLE_UNK00E10__LEN			0x00000004
+
+#define VIVS_RA_UNK00E20(i0)				       (0x00000e20 + 0x4*(i0))
+#define VIVS_RA_UNK00E20__ESIZE					0x00000004
+#define VIVS_RA_UNK00E20__LEN					0x00000004
 
 #define VIVS_RA_CENTROID_TABLE(i0)			       (0x00000e40 + 0x4*(i0))
 #define VIVS_RA_CENTROID_TABLE__ESIZE				0x00000004
@@ -484,6 +498,12 @@ DEALINGS IN THE SOFTWARE.
 #define VIVS_PS_RANGE_HIGH__MASK				0xffff0000
 #define VIVS_PS_RANGE_HIGH__SHIFT				16
 #define VIVS_PS_RANGE_HIGH(x)					(((x) << VIVS_PS_RANGE_HIGH__SHIFT) & VIVS_PS_RANGE_HIGH__MASK)
+
+#define VIVS_PS_UNK01024					0x00001024
+
+#define VIVS_PS_UNK01028					0x00001028
+
+#define VIVS_PS_UNK01030					0x00001030
 
 #define VIVS_PS_INST_MEM(i0)				       (0x00006000 + 0x4*(i0))
 #define VIVS_PS_INST_MEM__ESIZE					0x00000004
@@ -707,6 +727,8 @@ DEALINGS IN THE SOFTWARE.
 
 #define VIVS_PE_UNK014B4					0x000014b4
 
+#define VIVS_PE_UNK014B8					0x000014b8
+
 #define VIVS_PE_UNK01580(i0)				       (0x00001580 + 0x4*(i0))
 #define VIVS_PE_UNK01580__ESIZE					0x00000004
 #define VIVS_PE_UNK01580__LEN					0x00000003
@@ -844,7 +866,14 @@ DEALINGS IN THE SOFTWARE.
 #define VIVS_RS_EXTRA_CONFIG_ENDIAN__SHIFT			8
 #define VIVS_RS_EXTRA_CONFIG_ENDIAN(x)				(((x) << VIVS_RS_EXTRA_CONFIG_ENDIAN__SHIFT) & VIVS_RS_EXTRA_CONFIG_ENDIAN__MASK)
 
+#define VIVS_RS_UNK016B0					0x000016b0
+
 #define VIVS_RS_UNK016B4					0x000016b4
+
+#define VIVS_RS_UNK016B8					0x000016b8
+#define VIVS_RS_UNK016B8_UNK0					0x00000001
+
+#define VIVS_RS_UNK016BC					0x000016bc
 
 #define VIVS_RS_PIPE(i0)				       (0x00000000 + 0x4*(i0))
 #define VIVS_RS_PIPE__ESIZE					0x00000004
@@ -1166,6 +1195,10 @@ DEALINGS IN THE SOFTWARE.
 #define VIVS_SH_UNK0C000_MIRROR(i0)			       (0x00008000 + 0x4*(i0))
 #define VIVS_SH_UNK0C000_MIRROR__ESIZE				0x00000004
 #define VIVS_SH_UNK0C000_MIRROR__LEN				0x00001000
+
+#define VIVS_SH_UNIFORMS(i0)				       (0x00030000 + 0x4*(i0))
+#define VIVS_SH_UNIFORMS__ESIZE					0x00000004
+#define VIVS_SH_UNIFORMS__LEN					0x00000400
 
 
 #endif /* STATE_3D_XML */


### PR DESCRIPTION
The GC3000 in i.MX6qp refuses to render lines when WIDE_LINE mode disabled.

This feature has existed for a long time (gc880, gc1000, ...) and the Vivante driver always uses it when available, even to draw "non-wide" lines. So should we, as the backward compatibility has been dropped.

Set the bit (when the feature is available) and the associated state.

Signed-off-by: Wladimir J. van der Laan <laanwj@gmail.com>

(let me know if I should do an update of the rnndb files first to rename the states from UNKxxx. Related etna_viv commit: https://github.com/etnaviv/etna_viv/commit/964a55bde1e7494057c1bcb2e4435376d5e88fd9)

Video: https://www.youtube.com/watch?v=KH1ApjtCCLg

Replaces #1.