### PR TITLE
etnaviv: Implement primitive restart

### DIFF
--- a/src/gallium/drivers/etnaviv/etnaviv_context.h
+++ b/src/gallium/drivers/etnaviv/etnaviv_context.h
@@ -47,6 +47,7 @@ struct etna_index_buffer {
    struct pipe_index_buffer ib;
    struct etna_reloc FE_INDEX_STREAM_BASE_ADDR;
    uint32_t FE_INDEX_STREAM_CONTROL;
+   uint32_t FE_PRIMITIVE_RESTART_INDEX;
 };
 
 struct etna_shader_input {

--- a/src/gallium/drivers/etnaviv/etnaviv_emit.c
+++ b/src/gallium/drivers/etnaviv/etnaviv_emit.c
@@ -377,6 +377,11 @@ etna_emit_state(struct etna_context *ctx)
    if (likely(dirty & (ETNA_DIRTY_VERTEX_BUFFERS))) {
       /*0064C*/ EMIT_STATE_RELOC(FE_VERTEX_STREAM_BASE_ADDR, &ctx->vertex_buffer.cvb[0].FE_VERTEX_STREAM_BASE_ADDR);
       /*00650*/ EMIT_STATE(FE_VERTEX_STREAM_CONTROL, ctx->vertex_buffer.cvb[0].FE_VERTEX_STREAM_CONTROL);
+   }
+   if (likely(dirty & (ETNA_DIRTY_INDEX_BUFFER))) {
+      /*00674*/ EMIT_STATE(FE_PRIMITIVE_RESTART_INDEX, ctx->index_buffer.FE_PRIMITIVE_RESTART_INDEX);
+   }
+   if (likely(dirty & (ETNA_DIRTY_VERTEX_BUFFERS))) {
       for (int x = 1; x < ctx->vertex_buffer.count; ++x) {
          /*00680*/ EMIT_STATE_RELOC(FE_VERTEX_STREAMS_BASE_ADDR(x), &ctx->vertex_buffer.cvb[x].FE_VERTEX_STREAM_BASE_ADDR);
       }

--- a/src/gallium/drivers/etnaviv/etnaviv_screen.c
+++ b/src/gallium/drivers/etnaviv/etnaviv_screen.c
@@ -149,6 +149,9 @@ etna_screen_get_param(struct pipe_screen *pscreen, enum pipe_cap param)
       return true; /* VIV_FEATURE(priv->dev, chipMinorFeatures1,
                       NON_POWER_OF_TWO); */
 
+   case PIPE_CAP_PRIMITIVE_RESTART:
+      return VIV_FEATURE(screen, chipMinorFeatures1, HALTI0);
+
    case PIPE_CAP_ENDIANNESS:
       return PIPE_ENDIAN_LITTLE; /* on most Viv hw this is configurable (feature
                                     ENDIANNESS_CONFIG) */
@@ -158,7 +161,6 @@ etna_screen_get_param(struct pipe_screen *pscreen, enum pipe_cap param)
    case PIPE_CAP_TEXTURE_SWIZZLE: /* XXX supported on gc2000 */
    case PIPE_CAP_COMPUTE: /* XXX supported on gc2000 */
    case PIPE_CAP_MIXED_COLORBUFFER_FORMATS: /* only one colorbuffer supported, so mixing makes no sense */
-   case PIPE_CAP_PRIMITIVE_RESTART: /* primitive restart index AFAIK not supported */
    case PIPE_CAP_CONDITIONAL_RENDER: /* no occlusion queries */
    case PIPE_CAP_TGSI_INSTANCEID: /* no idea, really */
    case PIPE_CAP_START_INSTANCE: /* instancing not supported AFAIK */


### PR DESCRIPTION
Primitive restart is supported on Vivante hardware with the HALTI0 feature (gc860, gc2000, gc3000).

To support draw_info-dependent state changes, add a function etna_update_state_for_draw that updates the index buffer state according to the draw state.

This is one small step on the way to ES3. As there is no ES2 extension for primitive restart, to test this you currently need to force the GL ES version to 3 with `export MESA_GLES_VERSION_OVERRIDE=3.0`.